### PR TITLE
It doesn't make sense to wait one hour for a server to restart.

### DIFF
--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -355,7 +355,7 @@ func waitForServerStatus(d *schema.ResourceData, meta interface{}, pending []str
 		Pending:    pending,
 		Target:     []string{target},
 		Refresh:    newServerRefreshFunc(d, attribute, meta),
-		Timeout:    60 * time.Minute,
+		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}


### PR DESCRIPTION
It usually takes significantly less than a minute. This doesn't include the
start of the actual linux. 5 minutes should easily be enough.