### PR TITLE
ED25519 is considered to be safer than NIST P-256

### DIFF
--- a/website/docs/r/floating_ip.markdown
+++ b/website/docs/r/floating_ip.markdown
@@ -18,7 +18,7 @@ resource "cloudscale_server" "web-worker01" {
   name        = "web-worker01"
   flavor_slug = "flex-4"
   image_slug  = "debian-9"
-  ssh_keys    = ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFEepRNW5hDct4AdJ8oYsb4lNP5E9XY5fnz3ZvgNCEv7m48+bhUjJXUPuamWix3zigp2lgJHC6SChI/okJ41GUY="]
+  ssh_keys    = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL2jzgla23DfRVLQr3KT20QQYovqCCN3clHrjm2ZuQFW user@example.com"]
 }
 
 # Add a Floating IPv4 address to web-worker01


### PR DESCRIPTION
Yes, this is a nerd commit but we do trust ED25519 more than NIST.