### PR TITLE
ED25519 is considered to be safer than NIST P-256

### DIFF
--- a/website/docs/r/server.markdown
+++ b/website/docs/r/server.markdown
@@ -20,7 +20,7 @@ resource "cloudscale_server" "web-worker01" {
   image_slug          = "debian-9"
   volume_size_gb      = 10
   bulk_volume_size_gb = 200
-  ssh_keys            = ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFEepRNW5hDct4AdJ8oYsb4lNP5E9XY5fnz3ZvgNCEv7m48+bhUjJXUPuamWix3zigp2lgJHC6SChI/okJ41GUY="]
+  ssh_keys            = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL2jzgla23DfRVLQr3KT20QQYovqCCN3clHrjm2ZuQFW user@example.com"]
 }
 ```
 


### PR DESCRIPTION
Yes, this is a nerd commit but we do trust ED25519 more than NIST.